### PR TITLE
Added playbook to enable IPMI over lan

### DIFF
--- a/enable-ipmi-over-lan.yml
+++ b/enable-ipmi-over-lan.yml
@@ -1,0 +1,10 @@
+---
+- gather_facts: False
+  name: enable ipmi management over lan
+  hosts: all
+  tasks:
+    - name: enable ipmi management over lan
+      raw: racadm set iDRAC.IPMILan.Enable 1
+      register: result
+      failed_when: "'ERROR' in result.stdout or 'COMMAND PROCESSING FAILED' in result.stdout or 'error' in result.stdout or result.rc != 0"
+    - debug: var=result


### PR DESCRIPTION
Added enable-ipmi-over-lan.yml which will allow IPMI commands to
be sent to the drac via lan. This is needed when using an ironic
driver like pxe_ipmitool